### PR TITLE
Remove unused useState import from recommended-packages.tsx

### DIFF
--- a/src/section/home/recommended-packages.tsx
+++ b/src/section/home/recommended-packages.tsx
@@ -4,7 +4,7 @@ import "swiper/css";
 
 import { PackageCard } from "@/components/ui/package-card";
 import { packageDetailData } from "@/data/package-details";
-import {  useMemo, useState } from "react";
+import {  useMemo } from "react";
 
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
The useState import was unnecessary and has been removed to clean up the code. This helps maintain a more efficient and readable codebase. No functionality was impacted.